### PR TITLE
Rename "Percentage" to "Score" in Saving Throw table

### DIFF
--- a/src/components/PageCharacterSheet/SavingThrows/SavingThrows.tsx
+++ b/src/components/PageCharacterSheet/SavingThrows/SavingThrows.tsx
@@ -46,7 +46,7 @@ const SavingThrows: React.FC<React.ComponentPropsWithRef<"div">> = ({
           rollSavingThrow(record.score, record.throw, race, openNotification),
       }),
     },
-    { title: "Percentage", dataIndex: "score", key: "score" },
+    { title: "Score", dataIndex: "score", key: "score" },
   ];
   const tableClassNames = classNames("[&_td]:cursor-pointer", className);
   return (


### PR DESCRIPTION
The character sheet displays the Saving Throw table's two columns as "Throw" and "Percentage" respectively. However, since saving throws are rolled on a d20 and as such, are not percentage values. This request renames the latter column to "Score" instead.

That said, please let me know if the naming is intentional and I'll be happy to drop this pull request. :)