### PR TITLE
StepHitPoints: Remove leading '1' from the hitpoints edit display

### DIFF
--- a/src/components/PageNewCharacter/StepHitPoints/StepHitPoints.tsx
+++ b/src/components/PageNewCharacter/StepHitPoints/StepHitPoints.tsx
@@ -42,7 +42,8 @@ const StepHitPoints: React.FC<
         <Space.Compact>
           <InputNumber value={max} />
           <Button onClick={handleButtonClick}>
-            Roll {character.hp.dice}
+            Roll&nbsp;{character.level === 1 && "1"}
+            {character.hp.dice}
             {character.abilities.modifiers.constitution}
           </Button>
         </Space.Compact>

--- a/src/components/PageNewCharacter/StepHitPoints/StepHitPoints.tsx
+++ b/src/components/PageNewCharacter/StepHitPoints/StepHitPoints.tsx
@@ -42,7 +42,7 @@ const StepHitPoints: React.FC<
         <Space.Compact>
           <InputNumber value={max} />
           <Button onClick={handleButtonClick}>
-            Roll 1{character.hp.dice}
+            Roll {character.hp.dice}
             {character.abilities.modifiers.constitution}
           </Button>
         </Space.Compact>


### PR DESCRIPTION
The StepHitPoints component displays a leading '1' to the HP display which works fine for level 1 characters but as the character's hit dice increase this results in erroneous display e.g. 12d4 for a 2nd level magic user. This change removes the leading '1'. This fixes the issue for levels 2+ but results in the HD for 1st level characters showing without a number prefix.

Another search and replace bug fix although I'm not sure if the side effect on the HP display of level 1 characters is acceptable.