### PR TITLE
only remove the first custom equipment item

### DIFF
--- a/src/components/PageCharacterSheet/CollapseEquipment/EquipmentItemDescription/EquipmentItemDescription.tsx
+++ b/src/components/PageCharacterSheet/CollapseEquipment/EquipmentItemDescription/EquipmentItemDescription.tsx
@@ -29,11 +29,12 @@ const confirm = (
   character: CharData,
   setCharacter: (character: CharData) => void,
 ) => {
+  const eqp_idx = character.equipment.findIndex((e) => e === item);
+  if (eqp_idx >= 0) {
+    character.equipment.splice(eqp_idx, 1);
+  }
+  setCharacter(character);
   message.success(`${item.name} deleted`);
-  setCharacter({
-    ...character,
-    equipment: character.equipment.filter((e) => e.name !== item.name),
-  });
 };
 
 const cancel = () => {};

--- a/src/components/PageCharacterSheet/CollapseEquipment/EquipmentItemDescription/EquipmentItemDescription.tsx
+++ b/src/components/PageCharacterSheet/CollapseEquipment/EquipmentItemDescription/EquipmentItemDescription.tsx
@@ -29,11 +29,12 @@ const confirm = (
   character: CharData,
   setCharacter: (character: CharData) => void,
 ) => {
-  const eqp_idx = character.equipment.findIndex((e) => e === item);
-  if (eqp_idx >= 0) {
-    character.equipment.splice(eqp_idx, 1);
-  }
-  setCharacter(character);
+  const characterEquipment = [...character.equipment];
+  const itemIndex = characterEquipment.findIndex((e) => e === item);
+  setCharacter({
+    ...character,
+    equipment: characterEquipment.filter((_, i) => i !== itemIndex),
+  });
   message.success(`${item.name} deleted`);
 };
 


### PR DESCRIPTION
If you had multiple items with the same name, it would remove *all* items that shared a name.
Now checks the entire item, not just the name, and removes only the first match.

If you had several custom items named "scroll", with the `Notes` field containing different spells, previously this would remove all of them